### PR TITLE
support cloudwatch logs and service role for assumed by the task

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,12 +44,13 @@ resource "aws_ssm_maintenance_window_target" "scan" {
 }
 
 resource "aws_ssm_maintenance_window_task" "scan" {
-  max_concurrency = var.max_scan_concurrency
-  max_errors      = var.max_scan_errors
-  priority        = 1
-  task_type       = "RUN_COMMAND"
-  task_arn        = "AWS-RunPatchBaseline"
-  window_id       = aws_ssm_maintenance_window.scan.id
+  max_concurrency  = var.max_scan_concurrency
+  max_errors       = var.max_scan_errors
+  priority         = 1
+  service_role_arn = var.service_role_arn
+  task_type        = "RUN_COMMAND"
+  task_arn         = "AWS-RunPatchBaseline"
+  window_id        = aws_ssm_maintenance_window.scan.id
 
   targets {
     key    = "WindowTargetIds"
@@ -78,6 +79,15 @@ resource "aws_ssm_maintenance_window_task" "scan" {
           notification_type   = notification_config.value.notification_type
         }
       }
+
+      dynamic "cloudwatch_config" {
+        for_each = var.scan_cloudwatch_configs
+
+        content {
+          cloudwatch_log_group_name = cloudwatch_config.value.cloudwatch_log_group_name
+          cloudwatch_output_enabled = cloudwatch_config.value.cloudwatch_output_enabled
+        }
+      }
     }
   }
 }
@@ -94,12 +104,13 @@ resource "aws_ssm_maintenance_window_target" "install" {
 }
 
 resource "aws_ssm_maintenance_window_task" "install" {
-  max_concurrency = var.max_install_concurrency
-  max_errors      = var.max_install_errors
-  priority        = 1
-  task_type       = "RUN_COMMAND"
-  task_arn        = "AWS-RunPatchBaseline"
-  window_id       = aws_ssm_maintenance_window.install.id
+  max_concurrency  = var.max_install_concurrency
+  max_errors       = var.max_install_errors
+  priority         = 1
+  service_role_arn = var.service_role_arn
+  task_type        = "RUN_COMMAND"
+  task_arn         = "AWS-RunPatchBaseline"
+  window_id        = aws_ssm_maintenance_window.install.id
 
   targets {
     key    = "WindowTargetIds"
@@ -126,6 +137,15 @@ resource "aws_ssm_maintenance_window_task" "install" {
           notification_arn    = notification_config.value.notification_arn
           notification_events = notification_config.value.notification_events
           notification_type   = notification_config.value.notification_type
+        }
+      }
+
+      dynamic "cloudwatch_config" {
+        for_each = var.install_cloudwatch_configs
+
+        content {
+          cloudwatch_log_group_name = cloudwatch_config.value.cloudwatch_log_group_name
+          cloudwatch_output_enabled = cloudwatch_config.value.cloudwatch_output_enabled
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,16 @@ variable "scan_notification_configs" {
   }
 }
 
+variable "scan_cloudwatch_configs" {
+  default     = []
+  description = "A set of objects containing `cloudwatch_config`s [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_maintenance_window_task#cloudwatch_config)"
+
+  type = set(object({
+    cloudwatch_log_group_name = string
+    cloudwatch_output_enabled = bool
+  }))
+}
+
 variable "scan_schedule" {
   description = "6-field Cron expression describing the scan maintenance schedule"
   type        = string
@@ -209,9 +219,9 @@ variable "install_notification_configs" {
   description = "A set of objects containing `notification_config`s [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_maintenance_window_task#notification_config)"
 
   type = set(object({
-    notification_arn      = string
-    notification_events   = list(string)
-    notification_type     = string
+    notification_arn    = string
+    notification_events = list(string)
+    notification_type   = string
   }))
 
   validation {
@@ -257,6 +267,16 @@ variable "install_notification_configs" {
       )
     )
   }
+}
+
+variable "install_cloudwatch_configs" {
+  default     = []
+  description = "A set of objects containing `cloudwatch_config`s [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_maintenance_window_task#cloudwatch_config)"
+
+  type = set(object({
+    cloudwatch_log_group_name = string
+    cloudwatch_output_enabled = bool
+  }))
 }
 
 variable "install_schedule" {

--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,7 @@ variable "scan_cloudwatch_configs" {
 variable "scan_schedule" {
   description = "6-field Cron expression describing the scan maintenance schedule"
   type        = string
+  default     = "cron(35 14 * * ? *)"
 }
 
 variable "schedule_timezone" {
@@ -282,4 +283,11 @@ variable "install_cloudwatch_configs" {
 variable "install_schedule" {
   description = "6-field Cron expression describing the install maintenance schedule"
   type        = string
+  default     = "cron(35 14 * * ? *)"
+}
+
+variable "service_role_arn" {
+  description = "The role that should be assumed when executing the task"
+  type        = string
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -176,7 +176,6 @@ variable "scan_cloudwatch_configs" {
 variable "scan_schedule" {
   description = "6-field Cron expression describing the scan maintenance schedule"
   type        = string
-  default     = "cron(35 14 * * ? *)"
 }
 
 variable "schedule_timezone" {
@@ -283,7 +282,6 @@ variable "install_cloudwatch_configs" {
 variable "install_schedule" {
   description = "6-field Cron expression describing the install maintenance schedule"
   type        = string
-  default     = "cron(35 14 * * ? *)"
 }
 
 variable "service_role_arn" {


### PR DESCRIPTION
## **what**
add support for `cloudwatch_config` and `service_role_arn`

## **why**
improve module

## **references**
[Terraform documentation: aws_ssm_maintenance_window_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_maintenance_window_task#cloudwatch_log_group_name)
[Terraform documentation: aws_ssm_maintenance_window_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_maintenance_window_task#service_role_arn)